### PR TITLE
Add "api" subdirectory to the host path.

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -5,7 +5,7 @@ info:
   description: This specification outlines proposed API design for OS Hub to facilitate discussions and gather feedback before development begins.
   version: 1.0.0
 servers:
-  - url: http://localhost:8095
+  - url: http://localhost:8095/api
     description: Local development server
 tags:
   - name: countries


### PR DESCRIPTION
Since all the API endpoints should have an `api` subdirectory in their path to clearly indicate that it is an API endpoint, the API spec was edited accordingly.