### PR TITLE
Add os_id filter param

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -707,6 +707,12 @@ paths:
             type: string
             minLength: 1
             maxLength: 255
+        - name: os_id
+          in: query
+          description: Filter using the unique identifier of the location.
+          required: false
+          schema:
+            type: string
         - name: name
           in: query
           description: Filter using the name of the location.


### PR DESCRIPTION
PR in addition to https://opensupplyhub.atlassian.net/browse/OSDEV-982
Update specs for GET `/production-locations` to handle `os_id` as filter param.