### PR TITLE
[OSDEV-1126] Add historical_os_id field to the example response of the production-locations endpoint

### DIFF
--- a/docs/schemas/location_base.json
+++ b/docs/schemas/location_base.json
@@ -116,6 +116,13 @@
       "items": {
         "type": "string"
       }
+    },
+    "historical_os_id": {
+      "type": "array",
+      "description": "The historical unique identifiers for a location",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": ["name", "address", "country"]


### PR DESCRIPTION
[OSDEV-1126](https://opensupplyhub.atlassian.net/browse/OSDEV-1126) - SLC. Implement OS ID search (BE).

Added `historical_os_id` field to the example response of the `/v1/production-locations` endpoint.
