### PR TITLE
[OSDEV-1131] Add sort_by parameter to moderation events

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1358,6 +1358,24 @@ paths:
           schema:
             type: string
             format: date-time
+        - name: sort_by
+          in: query
+          description: The field to sort the results by.
+          required: false
+          default: created_at
+          schema:
+            type: string
+            enum: [
+              created_at,
+              moderation_decision_date,
+              updated_at,
+              name,
+              country,
+              contributor,
+              match_status,
+              moderation_status,
+            ]
+        - $ref: "#/components/parameters/order_by"
       description: >
         Returns an array of moderation events.
         Moderation events data for the search becomes available 15 minutes after upload to the system.

--- a/docs/schemas/moderation_event.json
+++ b/docs/schemas/moderation_event.json
@@ -16,6 +16,10 @@
             "type": "string",
             "format": "date-time"
           },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
           "os_id": {
             "type": "string",
             "description": "The unique identifier for a location"


### PR DESCRIPTION
Follow-up PR to [OSDEV-1331](https://opensupplyhub.atlassian.net/browse/OSDEV-1331)
1. Add sort_by and order_by parameters to `GET v1/moderation-events` request.
2. Add missing `updated_at` parameter to response of `GET v1/moderation-events` , `GET v1/moderation-events/{moderation-id}` and `PATCH v1/moderation-events/{moderation-id}`.