### PR TITLE
Made the cleaned_data field required in the moderation event response

### DIFF
--- a/docs/schemas/moderation_event.json
+++ b/docs/schemas/moderation_event.json
@@ -74,6 +74,7 @@
     "contributor_id",
     "contributor_name",
     "request_type",
-    "status"
+    "status",
+    "cleaned_data"
   ]
 }


### PR DESCRIPTION
The `cleaned_data` field must always be present in the response, as it contains core information about the moderation event. That's why this field has been made required.