### PR TITLE
[OSDEV-1453] Use the 'detail' keyword instead of 'message' and add a trailing slash at the end of each V1 endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -27,7 +27,7 @@ tags:
   - name: moderation-events
     description: Operations related to moderation events
 paths:
-  /v1/contributors:
+  /v1/contributors/:
     get:
       parameters:
         - $ref: "#/components/parameters/limit"
@@ -154,10 +154,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request query is invalid."
+                detail: "The request query is invalid."
                 errors:
                   - field: "email"
-                    message: "The value must be a valid email."
+                    detail: "The value must be a valid email."
         500:
           description: Internal Server Error
           content:
@@ -165,7 +165,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
     post:
       summary: Create a new contributor.
       description: >
@@ -192,10 +192,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request body is invalid."
+                detail: "The request body is invalid."
                 errors:
                   - field: "email"
-                    message: "The value must be a valid email."
+                    detail: "The value must be a valid email."
         500:
           description: Internal Server Error
           content:
@@ -203,8 +203,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
-  /v1/contributors/{user_id}:
+                detail: "An unexpected error occurred while processing the request."
+  /v1/contributors/{user_id}/:
     parameters:
       - name: user_id
         in: path
@@ -232,7 +232,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The contributor with the given id was not found."
+                detail: "The contributor with the given id was not found."
         500:
           description: Internal Server Error
           content:
@@ -240,7 +240,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
     put:
       summary: Update an existing contributor.
       description: >
@@ -267,7 +267,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The contributor with the given id was not found."
+                detail: "The contributor with the given id was not found."
         422:
           description: Unprocessable Entity
           content:
@@ -275,10 +275,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request body is invalid."
+                detail: "The request body is invalid."
                 errors:
                   - field: "email"
-                    message: "The value must be a valid email."
+                    detail: "The value must be a valid email."
         500:
           description: Internal Server Error
           content:
@@ -286,7 +286,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
     patch:
       summary: Partially update an existing contributor.
       description: >
@@ -313,7 +313,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The contributor with the given id was not found."
+                detail: "The contributor with the given id was not found."
         422:
           description: Unprocessable Entity
           content:
@@ -321,10 +321,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request body is invalid."
+                detail: "The request body is invalid."
                 errors:
                   - field: "email"
-                    message: "The value must be a valid email."
+                    detail: "The value must be a valid email."
         500:
           description: Internal Server Error
           content:
@@ -332,7 +332,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
     delete:
       summary: Delete an existing contributor.
       description: >
@@ -349,7 +349,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The contributor with the given id was not found."
+                detail: "The contributor with the given id was not found."
         500:
           description: Internal Server Error
           content:
@@ -357,8 +357,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
-  /v1/countries:
+                detail: "An unexpected error occurred while processing the request."
+  /v1/countries/:
     get:
       summary: Get list of countries supported by the OS Hub platform.
       description: >
@@ -451,7 +451,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
         400:
           description: Bad Request
           content:
@@ -459,11 +459,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request query is invalid."
+                detail: "The request query is invalid."
                 errors:
                   - field: "search_after"
-                    message: "The value must be a valid id."
-  /v1/sectors:
+                    detail: "The value must be a valid id."
+  /v1/sectors/:
     get:
       parameters:
         - $ref: "#/components/parameters/limit"
@@ -508,7 +508,7 @@ paths:
                   - name: "Agriculture"
                   - name: "Apparel"
                   - name: "Information"
-  /v1/product-types:
+  /v1/product-types/:
     get:
       parameters:
         - $ref: "#/components/parameters/limit"
@@ -553,7 +553,7 @@ paths:
                   - name: "Accessories"
                   - name: "Belts"
                   - name: "Caps"
-  /v1/location-types:
+  /v1/location-types/:
     get:
       parameters:
         - $ref: "#/components/parameters/limit"
@@ -628,7 +628,7 @@ paths:
                       - name: "Printing"
                       - name: "Dyeing"
                       - name: "Laundering"
-  /v1/parent-companies:
+  /v1/parent-companies/:
     get:
       parameters:
         - $ref: "#/components/parameters/limit"
@@ -680,10 +680,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request query is invalid."
+                detail: "The request query is invalid."
                 errors:
                   - field: "name"
-                    message: "The value must be a non-empty string."
+                    detail: "The value must be a non-empty string."
         500:
           description: Internal Server Error
           content:
@@ -691,8 +691,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
-  /v1/production-locations:
+                detail: "An unexpected error occurred while processing the request."
+  /v1/production-locations/:
     get:
       summary: Get list of production locations exposed by the OS Hub platform.
       parameters:
@@ -795,10 +795,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request query is invalid."
+                detail: "The request query is invalid."
                 errors:
                   - field: "number_of_workers"
-                    message: "The value must be a valid object with `min` and `max` properties."
+                    detail: "The value must be a valid object with `min` and `max` properties."
         500:
           description: Internal Server Error
           content:
@@ -806,7 +806,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
     post:
       summary: Create a new location.
       description: >
@@ -833,12 +833,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request body is invalid."
+                detail: "The request body is invalid."
                 errors:
                   - field: "name"
-                    message: "The value must be a non-empty string."
+                    detail: "The value must be a non-empty string."
                   - field: "country"
-                    message: "The value must be a valid country code or name."
+                    detail: "The value must be a valid country code or name."
         500:
           description: Internal Server Error
           content:
@@ -846,8 +846,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
-  /v1/production-locations/{os_id}:
+                detail: "An unexpected error occurred while processing the request."
+  /v1/production-locations/{os_id}/:
     parameters:
       - name: os_id
         in: path
@@ -875,10 +875,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request query is invalid."
+                detail: "The request query is invalid."
                 errors:
                   - field: "os_id"
-                    message: "The value must be a valid id."
+                    detail: "The value must be a valid id."
         404:
           description: Not Found
           content:
@@ -886,7 +886,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The location with the given id was not found."
+                detail: "The location with the given id was not found."
         500:
           description: Internal Server Error
           content:
@@ -894,7 +894,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
     patch:
       summary: Partially update an existing location.
       description: >
@@ -921,7 +921,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The location with the given id was not found."
+                detail: "The location with the given id was not found."
         422:
           description: Unprocessable Entity
           content:
@@ -929,12 +929,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request body is invalid."
+                detail: "The request body is invalid."
                 errors:
                   - field: "name"
-                    message: "The value must be a non-empty string."
+                    detail: "The value must be a non-empty string."
                   - field: "country"
-                    message: "The value must be a valid country code or name."
+                    detail: "The value must be a valid country code or name."
         500:
           description: Internal Server Error
           content:
@@ -942,7 +942,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
     delete:
       summary: Delete an existing location.
       description: >
@@ -963,7 +963,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The location with the given id was not found."
+                detail: "The location with the given id was not found."
         500:
           description: Internal Server Error
           content:
@@ -971,8 +971,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
-  /v1/production-locations/{os_id}/contributions:
+                detail: "An unexpected error occurred while processing the request."
+  /v1/production-locations/{os_id}/contributions/:
     parameters:
       - name: os_id
         in: path
@@ -1002,7 +1002,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The location with the given id was not found."
+                detail: "The location with the given id was not found."
         500:
           description: Internal Server Error
           content:
@@ -1010,8 +1010,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
-  /v1/production-locations/{os_id}/claims:
+                detail: "An unexpected error occurred while processing the request."
+  /v1/production-locations/{os_id}/claims/:
     parameters:
       - name: os_id
         in: path
@@ -1041,7 +1041,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The location with the given id was not found."
+                detail: "The location with the given id was not found."
         500:
           description: Internal Server Error
           content:
@@ -1049,7 +1049,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
     post:
       summary: Claim a location.
       description: >
@@ -1081,7 +1081,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The location with the given id was not found."
+                detail: "The location with the given id was not found."
         422:
           description: Unprocessable Entity
           content:
@@ -1089,10 +1089,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request body is invalid."
+                detail: "The request body is invalid."
                 errors:
                   - field: "job_title"
-                    message: "The job title is required."
+                    detail: "The job title is required."
         500:
           description: Internal Server Error
           content:
@@ -1100,8 +1100,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
-  /v1/moderation-events:
+                detail: "An unexpected error occurred while processing the request."
+  /v1/moderation-events/:
     get:
       summary: Get list of moderation events exposed by the OS Hub platform.
       parameters:
@@ -1230,52 +1230,52 @@ paths:
                 invalid_moderation_id:
                   summary: Invalid `moderation_id`
                   value:
-                    message: "The request query is invalid."
+                    detail: "The request query is invalid."
                     errors:
                       - field: "moderation_id"
-                        message: "Moderation id must be a string with uuid format"
+                        detail: "Moderation id must be a string with uuid format"
                 invalid_status:
                   summary: Invalid `status`
                   value:
-                    message: "The request query is invalid."
+                    detail: "The request query is invalid."
                     errors:
                       - field: "status"
-                        message: "Moderation status must be one of PENDING, APPROVED or REJECTED."
+                        detail: "Moderation status must be one of PENDING, APPROVED or REJECTED."
                 invalid_request_type:
                   summary: Invalid `request_type`
                   value:
-                    message: "The request query is invalid."
+                    detail: "The request query is invalid."
                     errors:
                       - field: "request_type"
-                        message: "Request type must be one of CREATE, UPDATE, or CLAIM."
+                        detail: "Request type must be one of CREATE, UPDATE, or CLAIM."
                 invalid_country:
                   summary: Invalid `country`
                   value:
-                    message: "The request query is invalid."
+                    detail: "The request query is invalid."
                     errors:
                       - field: "country"
-                        message: "Country must be a valid alpha-2 country code."
+                        detail: "Country must be a valid alpha-2 country code."
                 invalid_date_gte:
                   summary: Invalid `date_gte`
                   value:
-                    message: "The request query is invalid."
+                    detail: "The request query is invalid."
                     errors:
                       - field: "date_gte"
-                        message: "The value must be a valid date string."
+                        detail: "The value must be a valid date string."
                 invalid_date_lt:
                   summary: Invalid `date_lt`
                   value:
-                    message: "The request query is invalid."
+                    detail: "The request query is invalid."
                     errors:
                       - field: "date_lt"
-                        message: "The value must be a valid date string."
+                        detail: "The value must be a valid date string."
                 invalid_date_range:
                   summary: Invalid `date_lt` and `date_gte`
                   value:
-                    message: "The request query is invalid."
+                    detail: "The request query is invalid."
                     errors:
                       - field: "date_lt"
-                        message: "Start date cannot be later than the end date."
+                        detail: "Start date cannot be later than the end date."
         500:
           description: Internal Server Error
           content:
@@ -1283,8 +1283,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
-  /v1/moderation-events/{moderation_id}:
+                detail: "An unexpected error occurred while processing the request."
+  /v1/moderation-events/{moderation_id}/:
     get:
       summary: Get moderation event by id.
       parameters:
@@ -1314,10 +1314,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request path parameter is invalid."
+                detail: "The request path parameter is invalid."
                 errors:
                   - field: "moderation_id"
-                    message: "Invalid UUID format."
+                    detail: "Invalid UUID format."
         401:
           description: Unauthorized
           content:
@@ -1333,7 +1333,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
     patch:
       summary: Change moderation event. Available only for data moderators.
       parameters:
@@ -1377,24 +1377,24 @@ paths:
                 invalid_moderation_id:
                   summary: Invalid `moderation_id`
                   value:
-                    message: "The request path parameter is invalid."
+                    detail: "The request path parameter is invalid."
                     errors:
                       - field: "moderation_id"
-                        message: "Invalid UUID format."
+                        detail: "Invalid UUID format."
                 invalid_status:
                   summary: Invalid `status`
                   value:
-                    message: "The request body contains invalid or missing fields."
+                    detail: "The request body contains invalid or missing fields."
                     errors:
                       - field: "status"
-                        message: "Moderation status must be one of PENDING, APPROVED or REJECTED."
+                        detail: "Moderation status must be one of PENDING, APPROVED or REJECTED."
                 missing_status:
                   summary: Missing `status`
                   value:
-                    message: "The request body contains invalid or missing fields."
+                    detail: "The request body contains invalid or missing fields."
                     errors:
                       - field: "status"
-                        message: "This field is required."
+                        detail: "This field is required."
         403:
           description: Forbidden
           content:
@@ -1410,10 +1410,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request path parameter is invalid."
+                detail: "The request path parameter is invalid."
                 errors:
                   - field: "moderation_id"
-                    message: "Moderation event not found."
+                    detail: "Moderation event not found."
         500:
           description: Internal Server Error
           content:
@@ -1421,8 +1421,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
-  /v1/moderation-events/{moderation_id}/production-locations:
+                detail: "An unexpected error occurred while processing the request."
+  /v1/moderation-events/{moderation_id}/production-locations/:
     parameters:
       - name: moderation_id
         in: path
@@ -1532,7 +1532,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "Moderation event not found."
+                detail: "Moderation event not found."
         400:
           description: Bad Request
           content:
@@ -1540,10 +1540,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "The request path parameter is invalid."
+                detail: "The request path parameter is invalid."
                 errors:
                   - field: "moderation_id"
-                    message: "Moderation id must be a valid string"
+                    detail: "Moderation id must be a valid string"
         500:
           description: Internal Server Error
           content:
@@ -1551,7 +1551,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/error"
               example:
-                message: "An unexpected error occurred while processing the request."
+                detail: "An unexpected error occurred while processing the request."
 components:
   schemas:
     claim:

--- a/docs/schemas/error.json
+++ b/docs/schemas/error.json
@@ -3,7 +3,7 @@
   "type": "object",
   "description": "This schema represents an error returned from the API",
   "properties": {
-    "message": {
+    "detail": {
       "type": "string",
       "description": "A message describing the error"
     },
@@ -25,7 +25,7 @@
             "type": "number",
             "description": "A code identifying the error"
           },
-          "message": {
+          "detail": {
             "type": "string",
             "description": "A message describing the error code"
           }
@@ -33,5 +33,5 @@
       }
     }
   },
-  "required": ["message"]
+  "required": ["detail"]
 }


### PR DESCRIPTION
[OSDEV-1453](https://opensupplyhub.atlassian.net/browse/OSDEV-1453)
Use the 'detail' keyword instead of 'message' in response objects, add a trailing slash at the end of each V1 endpoint.
<img width="400" alt="Screenshot 2024-11-27 at 16 11 11" src="https://github.com/user-attachments/assets/c04786bc-209f-4bdb-b82b-daffd7070ec0">
<img width="385" alt="Screenshot 2024-11-27 at 16 11 25" src="https://github.com/user-attachments/assets/ea2a458e-87a7-4eb7-be8b-0eb56402fe6f">
