### PR TITLE
[OSDEV-1482] GET api/v1/moderation-events/{moderation_id} should return single response instead of array

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1493,6 +1493,14 @@ paths:
                     detail: "Invalid UUID format."
         401:
           $ref: "#/components/responses/unauthorized"
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+              example:
+                detail: "The moderation event with the given uuid was not found."
         429:
           $ref: "#/components/responses/throttled"
         500:


### PR DESCRIPTION
[OSDEV-1482](https://opensupplyhub.atlassian.net/browse/OSDEV-1482) GET api/v1/moderation-events/{moderation_id} should return single response instead of array

- Added 404 for GET moderation-events/{moderation_id}