### PR TITLE
[OSDEV-1336] Added expected responses for the PATCH /api/v1/production-locations/{os_id} endpoint and updated its description. Corrected small typos.

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -900,7 +900,7 @@ paths:
         Creates a new moderation event for the production location
         creation with the given details.
 
-        You can use the GET `/v1/moderation-events/{moderation_id}`
+        You can use the GET `/v1/moderation-events/{moderation_id}/`
         endpoint to track the status of the moderation event created
         by this action.
       tags:
@@ -1017,8 +1017,13 @@ paths:
                 detail: "An unexpected error occurred while processing the request."
     patch:
       summary: Partially update an existing location.
-      description: >
-        Partially updates an existing location with the given details.
+      description: |
+        Creates a new moderation event to contribute to an existing
+        production location with the given details.
+        
+        You can use the GET `/v1/moderation-events/{moderation_id}/`
+        endpoint to track the status of the moderation event created
+        by this action.
       tags:
         - production-locations
       requestBody:
@@ -1034,8 +1039,21 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/location_update"
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/error"
+              example:
+                detail: "The request body is invalid."
+                errors:
+                  - field: "non_field_errors"
+                    detail: "Invalid data. Expected a dictionary (object), but got list."
         401:
           $ref: "#/components/responses/unauthorized"
+        403:
+          $ref: "#/components/responses/unconfirmed_user"
         404:
           description: Not Found
           content:
@@ -1067,6 +1085,8 @@ paths:
                 $ref: "#/components/schemas/error"
               example:
                 detail: "An unexpected error occurred while processing the request."
+        503:
+          $ref: "#/components/responses/data_upload_maintenance_error"
     delete:
       summary: Delete an existing location.
       description: >
@@ -1255,7 +1275,7 @@ paths:
 
             - `created_at`, `status_change_date`, `updated_at`: ISO 8601 date and time (date-time).
 
-            - `contributor_id`: Numeric ID (integer).
+            - `contributor_id`: Numeric id (integer).
 
             - `contributor_name`, `name`, `address`, `source`, `country`, `status`: Text (string).
 

--- a/docs/schemas/location_update.json
+++ b/docs/schemas/location_update.json
@@ -7,7 +7,8 @@
       "properties": {
         "os_id": {
           "type": "string",
-          "description": "The unique identifier for a location that represents current OS ID."
+          "example": "ID2024331V7D4T9",
+          "description": "The unique identifier for a location that represents current OS id."
         }
       }
     },

--- a/docs/schemas/moderation_base.json
+++ b/docs/schemas/moderation_base.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "description": "This schema represents base moderation field.",
+  "description": "This schema represents base moderation fields.",
   "properties": {
     "moderation_id": {
       "type": "string",


### PR DESCRIPTION
[[OSDEV-1336](https://opensupplyhub.atlassian.net/browse/OSDEV-1336)]
- Updated the description for PATCH `/api/v1/production-locations/{os_id}/` to clearly state that it creates a moderation event for contributing to an existing production location.
- Added responses for this endpoint, including 400 (Bad Request), 403 (Forbidden), and 503 (Too Many Requests), in addition to the previously provided ones.
- Added an example of the `os_id` field for the 202 response.
- Fixed small typos and changed "ID" to "id" for consistency across the documentation.