### PR TITLE
[OSDEV-1558] Add field to keep history of moderation event action that has been performed by data moderator

### DIFF
--- a/docs/schemas/moderation_event.json
+++ b/docs/schemas/moderation_event.json
@@ -53,6 +53,11 @@
       "enum": ["API", "SLC"],
       "description": "Source type of production location."
     },
+    "action_type": {
+      "type": "string",
+      "enum": ["NEW_LOCATION", "MATCHED", "REJECTED"],
+      "description": "Type of moderation action."
+    },
     "status": {
       "type": "string",
       "enum": ["PENDING", "APPROVED", "REJECTED"],


### PR DESCRIPTION
[OSDEV-1558](https://opensupplyhub.atlassian.net/browse/OSDEV-1558) Add field to keep history of moderation event action that has been performed by data moderator

- Updated API spec with new field **action_type** for moderation event.