### PR TITLE
[OSDEV-1577] Update the API specification after adding geo-bounding box support to the GET `/v1/production-locations/` endpoint.

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -553,6 +553,42 @@ paths:
             type: integer
             minimum: 0
             maximum: 15
+            example: 5
+        - name: geo_bounding_box
+          in: query
+          description: >
+            Filter using the bounding box. The bounding box is defined 
+            by the coordinates of its top, left, bottom, and right sides. 
+            All four coordinates must be specified.
+          required: false
+          schema:
+            type: object
+            required:
+              - top
+              - left
+              - bottom
+              - right
+            properties:
+              top:
+                type: number
+                minimum: -90
+                maximum: 90
+                example: 90
+              left:
+                type: number
+                minimum: -180
+                maximum: 180
+                example: -180
+              bottom:
+                type: number
+                minimum: -90
+                maximum: 90
+                example: -90
+              right:
+                type: number
+                minimum: -180
+                maximum: 180
+                example: 180
         - $ref: "#/components/parameters/size"
         - $ref: "#/components/parameters/from"
         - name: search_after[value]


### PR DESCRIPTION
[OSDEV-1577](https://opensupplyhub.atlassian.net/browse/OSDEV-1577) - Add Geo-bounding box support to the production locations endpoint.

In the current PR, the description of the `geo_bounding_box` query parameter for GET `/v1/production-locations/` endpoint was added.