### PR TITLE
[OSDEV-1748]  Align SLC with current v1/production-locations validation

### DIFF
--- a/docs/schemas/location_main.json
+++ b/docs/schemas/location_main.json
@@ -62,8 +62,7 @@
         "min": {
           "type": "number",
           "description": "The minimum number.",
-          "minimum": 1,
-          "exclusiveMaximum": { "$data": "1/max" }
+          "minimum": 1
         },
         "max": {
           "type": "number",


### PR DESCRIPTION
[OSDEV-1748](https://opensupplyhub.atlassian.net/browse/OSDEV-1748) Align SLC with current v1/production-locations validation.

Removed validation for number_of_workers field min>=max from schema for v1/production-locations.