### PR TITLE
[OSDEV-1779] Make parent_company field as a string

### DIFF
--- a/docs/schemas/cleaned_data_fields.json
+++ b/docs/schemas/cleaned_data_fields.json
@@ -65,17 +65,7 @@
       "required": ["raw_values", "processed_values"]
     },
     "parent_company": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
+      "type": "string"
     },
     "country": {
       "type": "string",

--- a/docs/schemas/cleaned_data_raw_json.json
+++ b/docs/schemas/cleaned_data_raw_json.json
@@ -53,17 +53,7 @@
       ]
     },
     "parent_company": {
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
+      "type": "string"
     },
     "processing_type": {
       "oneOf": [


### PR DESCRIPTION
Fix [OSDEV-1779](https://opensupplyhub.atlassian.net/browse/OSDEV-1779)
Make `parent_company`  field as string for:
1. 202 response body of POST `v1/production-locations`.
2. 202 response body of PATCH `v1/production-locations/{os_id}`.