### PR TITLE
[OSDEV-1782] Update the schema of the request body for the PATCH `v1/moderation-events/{moderation_id}/` endpoint.

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1154,6 +1154,8 @@ paths:
                     status:
                       type: string
                       enum: [PENDING, APPROVED]
+                  required:
+                    - status
                 - properties:
                     status:
                       type: string
@@ -1169,6 +1171,7 @@ paths:
                         The raw (html formatted) version of the action reason text.
                       minLength: 30
                   required:
+                    - status
                     - action_reason_text_cleaned
                     - action_reason_text_raw
       description: >


### PR DESCRIPTION
[OSDEV-1782](https://opensupplyhub.atlassian.net/browse/OSDEV-1782)

Added the `action_reason_text_cleaned` and `action_reson_text_raw` fields to the requestBody schema for the PATCH `v1/moderation-events/{moderation_id}/` endpoint.