### PR TITLE
Add maxLength constraint to the parent_company field

### DIFF
--- a/docs/schemas/location_source.json
+++ b/docs/schemas/location_source.json
@@ -81,6 +81,11 @@
               "description": "The processing type that defines the activities occurring at this production location from a more granular perspective. To provide more than one processing type value, you can use a comma (,) or a vertical bar (|) as delimiters between values."
             }
           ]
+        },
+        "parent_company": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "The name of the parent company of the location."
         }
       }
     },


### PR DESCRIPTION
[OSDEV-1706](https://opensupplyhub.atlassian.net/browse/OSDEV-1706)

It was noted that the `parent_company` field is limited to 200 characters on the backend for the `api/v1/production-locations/` (POST) and `api/v1/production-locations/{os_id}/` (PATCH) endpoints. To maintain consistency between endpoint validations and the API documentation, this constraint has been added to the API docs for these endpoints.