### PR TITLE
[OSDEV-1926] Add description for the additional identifiers.

### DIFF
--- a/docs/schemas/location_source.json
+++ b/docs/schemas/location_source.json
@@ -87,30 +87,24 @@
           "maxLength": 200,
           "description": "The name of the parent company of the location."
         },
-        "additional_identifiers": {
-          "type": "object",
-          "description": "Additional identifiers for the location.",
-          "properties": {
-            "duns_id": {
-              "type": "string",
-              "maxLength": 9,
-              "minLength": 9,
-              "pattern": "^[0-9]{9}$",
-              "description": "The DUNS ID of the location."
-            },
-            "lei_id": {
-              "type": "string",
-              "maxLength": 20,              
-              "minLength": 20,
-              "pattern": "^[A-Z0-9]{18}[0-9]{2}$",
-              "description": "The LEI ID of the location."
-            },
-            "rba_id": {
-              "type": "string",
-              "maxLength": 255,
-              "description": "The RBA ID of the location."
-            }
-          }
+        "duns_id": {
+          "type": "string",
+          "maxLength": 9,
+          "minLength": 9,
+          "pattern": "^[0-9]{9}$",
+          "description": "The DUNS ID of the location."
+        },
+        "lei_id": {
+          "type": "string",
+          "maxLength": 20,              
+          "minLength": 20,
+          "pattern": "^[A-Z0-9]{18}[0-9]{2}$",
+          "description": "The LEI ID of the location."
+        },
+        "rba_id": {
+          "type": "string",
+          "maxLength": 255,
+          "description": "The RBA ID of the location."
         }
       }
     },


### PR DESCRIPTION
[OSDEV-1926](https://opensupplyhub.atlassian.net/browse/OSDEV-1926) - [RBA Data Model] Allow submission of additional identifiers through the API.

This PR adds documentation for the `duns_id`, `lei_id`, and `rba_id` fields, which can be included in the request body when making POST` /v1/production-locations/` or PATCH `/v1/production-locations/{os_id}/ `API calls.







