### PR TITLE
[OSDEV-1952] Support for OS ID as a parent company in the production locations API

### DIFF
--- a/docs/schemas/cleaned_data_fields.json
+++ b/docs/schemas/cleaned_data_fields.json
@@ -78,6 +78,9 @@
     },
     {
       "$ref": "additional_identifiers.json"
+    },
+    {
+      "$ref": "parent_company_os_id.json"
     }
   ]
 }

--- a/docs/schemas/cleaned_data_raw_json.json
+++ b/docs/schemas/cleaned_data_raw_json.json
@@ -96,6 +96,9 @@
     },
     {
       "$ref": "additional_identifiers.json"
+    },
+    {
+      "$ref": "parent_company_os_id.json"
     }
   ]
 }

--- a/docs/schemas/location_source.json
+++ b/docs/schemas/location_source.json
@@ -94,6 +94,9 @@
     },
     {
       "$ref": "location_main.json"
+    },
+    {
+      "$ref": "parent_company_os_id.json"
     }
   ]
 }

--- a/docs/schemas/parent_company_os_id.json
+++ b/docs/schemas/parent_company_os_id.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "description": "This schema represents parent company os id object.",
+    "properties": {
+        "parent_company_os_id": {
+            "pattern": "[A-Z]{2}[0-9]{7}[A-Z0-9]{6}",
+            "description": "The OS ID of the parent company of the location.",
+            "oneOf": [
+                {
+                    "type": "array",
+                    "maxItems": 20,
+                    "description": "The OS ID of the parent company of the location.",
+                    "example": ["ID2024331V7D4T9"],
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "string",
+                    "description": "The OS ID of the parent company of the location. To provide more than one OS ID value, you can use a comma (,) or a vertical bar (|) as delimiters between values.",
+                    "example": "ID2024331V7D4T9"
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
[OSDEV-1952](https://opensupplyhub.atlassian.net/browse/OSDEV-1952) **Support for OS ID as a parent company in the production locations API**

Added documentation for the `parent_company_os_id` field in the request body & response of the following API endpoints:
- POST `/v1/production-locations/`
- PATCH `/v1/production-locations/{os_id}/`