### PR TITLE
[OSDEV-2089] Add geocoded_location_type and geocoded_address to GET /production-locaitons response

### DIFF
--- a/docs/schemas/location.json
+++ b/docs/schemas/location.json
@@ -28,6 +28,14 @@
         "claimed_at": {
           "type": "string",
           "description": "Represents the date of the claim update"
+        },
+        "geocoded_location_type": {
+          "type": "string",
+          "description": "Type of geocoded result (e.g., ROOFTOP, APPROXIMATE, RANGE_INTERPOLATED, GEOMETRIC_CENTER)."
+        },
+        "geocoded_address": {
+          "type": "string",
+          "description": "Normalized address string returned by geocoding."
         }
       }
     },


### PR DESCRIPTION
API spec for [OSDEV-2089](https://opensupplyhub.atlassian.net/browse/OSDEV-2089)
Added `geocoded_location_type` and `geocoded_address` fields to `GET /api/v1/production-locaitons` and  `GET /api/v1/production-locaitons/{os_id}` responses.