### PR TITLE
Make name, address and country in PATCH v1/production-locations/<os-id> optional

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -888,7 +888,7 @@ paths:
               example:
                 detail: "The location with the given id was not found."
         422:
-          $ref: "#/components/responses/unprocessable_entity"
+          $ref: "#/components/responses/unprocessable_entity_multifield"
         429:
           $ref: "#/components/responses/data_duplicate"
         500:
@@ -1531,6 +1531,8 @@ components:
       $ref: "responses/data_upload_maintenance_error.json"
     unprocessable_entity:
       $ref: "responses/unprocessable_entity.json"
+    unprocessable_entity_multifield:
+      $ref: "responses/unprocessable_entity_multifield.json"
     only_moderator:
       $ref: "responses/only_moderator.json"
     action_forbidden:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -745,6 +745,7 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/location_source"
+              required: ["name", "address", "country"]
       responses:
         202:
           description: Accepted

--- a/docs/responses/unprocessable_entity_multifield.json
+++ b/docs/responses/unprocessable_entity_multifield.json
@@ -1,0 +1,52 @@
+{
+    "description": "Unprocessable Entity with multiple fields",
+    "content": {
+        "application/json": {
+            "schema": {
+                "$ref": "../schemas/error.json"
+            },
+            "examples": {
+                "simple field": {
+                    "$ref": "unprocessable_entity.json#/content/application~1json/examples/simple%20field"
+                },
+                "nested fields": {
+                    "$ref": "unprocessable_entity.json#/content/application~1json/examples/nested%20fields"
+                },
+                "only_coordinates": {
+                    "value": {
+                        "detail": "The request body is invalid.",
+                        "errors": [
+                            {
+                                "field": "name",
+                                "detail": "Field name is required when coordinates are provided."
+                            },
+                            {
+                                "field": "address",
+                                "detail": "Field address is required when coordinates are provided."
+                            },
+                            {
+                                "field": "country",
+                                "detail": "Field country is required when coordinates are provided."
+                            }
+                        ]
+                    }
+                },
+                "missing_core_fields": {
+                    "value": {
+                        "detail": "The request body is invalid.",
+                        "errors": [
+                            {
+                                "field": "address",
+                                "detail": "Field address is required when name is provided."
+                            },
+                            {
+                                "field": "country",
+                                "detail": "Field country is required when name is provided."
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/docs/schemas/claim.json
+++ b/docs/schemas/claim.json
@@ -15,5 +15,6 @@
     {
       "$ref": "location_base.json"
     }
-  ]
+  ],
+  "required": ["name", "address", "country"]
 }

--- a/docs/schemas/claim_base.json
+++ b/docs/schemas/claim_base.json
@@ -55,7 +55,8 @@
         {
           "$ref": "location_base.json"
         }
-      ]
+      ],
+      "required": ["name", "address", "country"]
     }
   },
   "required": [

--- a/docs/schemas/location.json
+++ b/docs/schemas/location.json
@@ -34,5 +34,6 @@
     {
       "$ref": "additional_identifiers.json"
     }
-  ]
+  ],
+  "required" : ["name", "address", "country"]
 }

--- a/docs/schemas/location_contribution.json
+++ b/docs/schemas/location_contribution.json
@@ -28,5 +28,6 @@
     {
       "$ref": "location_base.json"
     }
-  ]
+  ],
+  "required" : ["name", "address", "country"]
 }

--- a/docs/schemas/location_main.json
+++ b/docs/schemas/location_main.json
@@ -93,6 +93,5 @@
       "required": ["lat", "lng"],
       "additionalProperties": false
     }
-  },
-  "required": ["name", "address", "country"]
+  }
 }


### PR DESCRIPTION
API spec update for [OSDEV-2122](https://opensupplyhub.atlassian.net/browse/OSDEV-2122)

Make `name`, `address` and `country` fields not required for `PATCH v1/production-locations/<os-id>` endpoint.
Add examples of error messages based on the logic behind the `name`, `address`, and `country` backfill process.