### PR TITLE
[OSDEV-2064] Introduce additional claim fields for single location endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -810,6 +810,7 @@ paths:
                 allOf:
                   - $ref: "#/components/schemas/location"
                   - $ref: "#/components/schemas/additional_claim_fields"
+                  - $ref: "#/components/schemas/additional_partner_fields"
         400:
           description: Bad Request
           content:
@@ -1524,6 +1525,8 @@ components:
       $ref: "schemas/error.json"
     additional_claim_fields:
       $ref: "schemas/additional_claim_fields.json"
+    additional_partner_fields:
+      $ref: "schemas/additional_partner_fields.json"
   responses:
     unauthorized:
       $ref: "responses/unauthorized.json"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -807,7 +807,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/location"
+                allOf:
+                  - $ref: "#/components/schemas/location"
+                  - $ref: "#/components/schemas/additional_claim_fields"
         400:
           description: Bad Request
           content:
@@ -1520,6 +1522,8 @@ components:
       $ref: "schemas/moderation_event.json"
     error:
       $ref: "schemas/error.json"
+    additional_claim_fields:
+      $ref: "schemas/additional_claim_fields.json"
   responses:
     unauthorized:
       $ref: "responses/unauthorized.json"

--- a/docs/schemas/additional_claim_fields.json
+++ b/docs/schemas/additional_claim_fields.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "description": "This schema represents additional claim fields object.",
+    "properties": {
+        "opened_at": {
+            "type": "string",
+            "format": "date",
+            "description": "The date when the location was opened (YYYY-MM-DD)."
+        },
+        "closed_at": {
+            "type": "string",
+            "format": "date",
+            "description": "The date when the location was closed (YYYY-MM-DD)."
+        },
+        "estimated_annual_throughput": {
+            "type": "number",
+            "description": "Estimated annual throughput."
+        },
+        "actual_annual_energy_consumption": {
+            "type": "array",
+            "description": "Actual annual energy consumption entries.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "source": {
+                        "type": "string",
+                        "description": "Energy source name (e.g., Electricity, Coal, Biomass)."
+                    },
+                    "amount": {
+                        "type": "number",
+                        "description": "Energy consumption amount."
+                    }
+                },
+                "required": ["source", "amount"],
+                "additionalProperties": false
+            }
+        }
+    }
+}

--- a/docs/schemas/additional_partner_fields.json
+++ b/docs/schemas/additional_partner_fields.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "description": "This schema represents additional partner fields object.",
+    "properties": {
+        "estimated_emissions_activity": {
+            "type": "number",
+            "description": "Estimated emmisions activity."
+        },
+        "estimated_annual_energy_consumption": {
+            "type": "array",
+            "description": "Estimated annual energy consumption entries.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "source": {
+                        "type": "string",
+                        "description": "Energy source name (e.g., Electricity, Coal, Biomass)."
+                    },
+                    "amount": {
+                        "type": "number",
+                        "description": "Energy consumption amount."
+                    }
+                },
+                "required": ["source", "amount"],
+                "additionalProperties": false
+            }
+        }
+    }
+}

--- a/docs/schemas/additional_partner_fields.json
+++ b/docs/schemas/additional_partner_fields.json
@@ -1,30 +1,59 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
-    "description": "This schema represents additional partner fields object.",
-    "properties": {
-        "estimated_emissions_activity": {
-            "type": "number",
-            "description": "Estimated emmisions activity."
-        },
-        "estimated_annual_energy_consumption": {
-            "type": "array",
-            "description": "Estimated annual energy consumption entries.",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "source": {
-                        "type": "string",
-                        "description": "Energy source name (e.g., Electricity, Coal, Biomass)."
-                    },
-                    "amount": {
-                        "type": "number",
-                        "description": "Energy consumption amount."
+    "description": "Dynamic additional partner fields configured at runtime.",
+    "patternProperties": {
+        "^[a-zA-Z_][a-zA-Z_]*$": {
+            "description": "Dynamic additional partner field value.",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "Text field value",
+                    "example": "ISO 14001"
+                },
+                {
+                    "type": "number",
+                    "format": "float",
+                    "description": "Numeric field value (float)",
+                    "example": 85.5
+                },
+                {
+                    "type": "array",
+                    "description": "Array field value",
+                    "example": [
+                        {
+                            "amount": 500,
+                            "source": "Electricity"
+                        },
+                        {
+                            "amount": 700,
+                            "source": "Coal"
+                        },
+                        {
+                            "amount": 900,
+                            "source": "Biomass"
+                        }
+                    ],
+                    "items": {
+                        "oneOf": [
+                            {"type": "string"},
+                            {"type": "number", "format": "float"},
+                            {"type": "boolean"},
+                            {"type": "object", "additionalProperties": true}
+                        ]
                     }
                 },
-                "required": ["source", "amount"],
-                "additionalProperties": false
-            }
+                {
+                    "type": "object",
+                    "description": "Complex object field value",
+                    "additionalProperties": true,
+                    "example": {
+                        "amount": 17,
+                        "source": "CO2"
+                    }
+                }
+            ]
         }
-    }
+    },
+    "additionalProperties": false
 }


### PR DESCRIPTION
API specs for [OSDEV-2064](https://opensupplyhub.atlassian.net/browse/OSDEV-2064)

Updated response schema for `GET /api/v1/production-locations/<os_id>`:

Claim fields:
1. `opened_at`,
2. `closed_at`,
3. `estimated_annual_throughput`,
4. `actual_annual_energy_consumption`

Partner fields:
1. `estimated_emissions_activity`
2. `estimated_annual_energy_consumption`