### PR TITLE
[OSDEV-2292] Improved ISIC-4 schema description, extended error schema for nested arrays, added an additional error example for ISIC-4

### DIFF
--- a/docs/responses/unprocessable_entity.json
+++ b/docs/responses/unprocessable_entity.json
@@ -10,10 +10,10 @@
           "value": {
             "detail": "The request body is invalid.",
             "errors": [
-                {
-                    "field": "name",
-                    "detail": "Field name must be a string, not a number."
-                }
+              {
+                "field": "name",
+                "detail": "Field name must be a string, not a number."
+              }
             ]
           }
         },
@@ -21,15 +21,40 @@
           "value": {
             "detail": "The request body is invalid.",
             "errors": [
-                {
-                    "field": "number_of_workers",
+              {
+                "field": "number_of_workers",
+                "errors": [
+                  {
+                    "field": "max",
+                    "detail": "The max field is required!"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "nested array of objects": {
+          "value": {
+            "detail": "The request body is invalid.",
+            "errors": [
+              {
+                "field": "isic_4",
+                "errors": [
+                  {
+                    "field": 0,
                     "errors": [
-                        {
-                            "field": "max",
-                            "detail": "The max field is required!"
-                        }
+                      {
+                        "field": "section",
+                        "detail": "Field section must be a non-empty string."
+                      },
+                      {
+                        "field": "division",
+                        "detail": "Field division must be a non-empty string."
+                      }
                     ]
-                }
+                  }
+                ]
+              }
             ]
           }
         }

--- a/docs/responses/unprocessable_entity_multifield.json
+++ b/docs/responses/unprocessable_entity_multifield.json
@@ -12,6 +12,9 @@
                 "nested fields": {
                     "$ref": "unprocessable_entity.json#/content/application~1json/examples/nested%20fields"
                 },
+                "nested array of objects": {
+                    "$ref": "unprocessable_entity.json#/content/application~1json/examples/nested%20fields%20with%20array%20of%20objects"
+                },
                 "only_coordinates": {
                     "value": {
                         "detail": "The request body is invalid.",

--- a/docs/schemas/error.json
+++ b/docs/schemas/error.json
@@ -40,11 +40,12 @@
                 "type": "string",
                 "description": "A specific message describing the error related to fields or the overall data object."
               }
-            }
+            },
+            "required": ["field", "detail"]
           },
           {
             "type": "object",
-            "description": "A nested error object that contains an array of simple errors.",
+            "description": "A nested error object that contains an array of errors. Supports multiple levels of nesting for complex structures like arrays and nested objects.",
             "properties": {
               "field": {
                 "type": "string",
@@ -52,9 +53,13 @@
               },
               "errors": {
                 "type": "array",
-                "description": "An array of nested errors.",
+                "description": "An array of nested errors. Each error can be either a simple error with field and detail, or another nested error with field and errors.",
                 "items": {
                   "type": "object",
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "description": "A simple nested error with a field and detail.",
                   "properties": {
                     "field": {
                       "type": "string",
@@ -66,6 +71,37 @@
                     }
                   },
                   "required": ["field", "detail"]
+                    },
+                    {
+                      "type": "object",
+                      "description": "A deeply nested error that contains another level of errors. Applicable for invalid root fields with array of objects.",
+                      "properties": {
+                        "field": {
+                            "type": "integer",
+                            "description": "The array index."
+                        },
+                        "errors": {
+                          "type": "array",
+                          "description": "Another level of nested errors.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "field": {
+                                  "type": "string",
+                                  "description": "The field name."
+                              },
+                              "detail": {
+                                "type": "string",
+                                "description": "A specific message describing the deeply nested error."
+                              }
+                            },
+                            "required": ["field", "detail"]
+                          }
+                        }
+                      },
+                      "required": ["field", "errors"]
+                    }
+                  ]
                 }
               }
             },

--- a/docs/schemas/isic_4_fields.json
+++ b/docs/schemas/isic_4_fields.json
@@ -31,7 +31,9 @@
             "minLength": 1,
             "description": "ISIC division value."
           }
-        }
+        },
+        "additionalProperties": false,
+        "minProperties": 1
       }
     }
   }


### PR DESCRIPTION
[OSDEV-2292](https://opensupplyhub.atlassian.net/browse/OSDEV-2292)

- Restricted ISIC-4 field items to only allow class, group, section, or division properties with at least one required
- Extended the `error.json` schema to support deeply nested validation errors with array index references
- Added an additional error example for fields that contain an array of nested objects.
- Added required field constraint to non-field error variant for consistency