### PR TITLE
[OSDEV-2292] Provided the correct import link for the "nested array of objects" error example

### DIFF
--- a/docs/responses/unprocessable_entity_multifield.json
+++ b/docs/responses/unprocessable_entity_multifield.json
@@ -13,7 +13,7 @@
                     "$ref": "unprocessable_entity.json#/content/application~1json/examples/nested%20fields"
                 },
                 "nested array of objects": {
-                    "$ref": "unprocessable_entity.json#/content/application~1json/examples/nested%20fields%20with%20array%20of%20objects"
+                    "$ref": "unprocessable_entity.json#/content/application~1json/examples/nested%20array%20of%20objects"
                 },
                 "only_coordinates": {
                     "value": {


### PR DESCRIPTION
[OSDEV-2292](https://opensupplyhub.atlassian.net/browse/OSDEV-2292)

This update adds the correct import link for the "nested array of objects" error example in the API documentation. The fix ensures that the example displays properly and references the correct schema source.
