### PR TITLE
[OSDEV-2401] Add backfilled_fields to moderation event schema

### DIFF
--- a/docs/schemas/moderation_event.json
+++ b/docs/schemas/moderation_event.json
@@ -74,6 +74,13 @@
     "claim_id": {
       "type": "number",
       "description": "Linked claim id for this production location."
+    },
+    "backfilled_fields": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of field names that were backfilled from existing production location data when the API user did not provide them in a PATCH request. Helps moderators distinguish backfilled data from data provided by the API user."
     }
   },
   "required": [


### PR DESCRIPTION
[OSDEV-2401](https://opensupplyhub.atlassian.net/browse/OSDEV-2401)

Updates the API docs so the moderation event schema includes the new `backfilled_fields` field, in line with [open-supply-hub#921](https://github.com/opensupplyhub/open-supply-hub/pull/921).