### PR TITLE
[OSDEV-2920] Add os_id_snapshot to moderation_event schema

### DIFF
--- a/docs/schemas/moderation_event.json
+++ b/docs/schemas/moderation_event.json
@@ -18,7 +18,11 @@
     },
     "os_id": {
       "type": "string",
-      "description": "The unique identifier for a location."
+      "description": "The unique identifier for a location. Falls back to os_id_snapshot when the live facility reference has been nulled by a facility deletion or merge."
+    },
+    "os_id_snapshot": {
+      "type": "string",
+      "description": "The OS ID recorded at approval time. Preserved (never cleared), so it survives facility deletion or merge. Null when unset."
     },
     "cleaned_data": {
       "type": "object",

--- a/docs/schemas/moderation_event.json
+++ b/docs/schemas/moderation_event.json
@@ -18,11 +18,11 @@
     },
     "os_id": {
       "type": "string",
-      "description": "The unique identifier for a location. Falls back to os_id_snapshot when the live facility reference has been nulled by a facility deletion or merge."
+      "description": "The unique identifier for a location. Serves os_id_snapshot (the OS ID recorded at approval) when set, falling back to the live facility reference only when the snapshot is unset — so the originally-approved OS ID survives a facility deletion or merge. When neither exists, the field is null (PATCH) or omitted (GET)."
     },
     "os_id_snapshot": {
       "type": "string",
-      "description": "The OS ID recorded at approval time. Preserved (never cleared), so it survives facility deletion or merge. Null when unset."
+      "description": "The OS ID recorded at approval time. Preserved (never cleared), so it survives facility deletion or merge. When unset, the field is null (PATCH) or omitted (GET)."
     },
     "cleaned_data": {
       "type": "object",


### PR DESCRIPTION
## Summary

Adds `os_id_snapshot` to the shared `moderation_event` schema and updates the `os_id` description to note the snapshot fallback (when the live facility reference is nulled by a delete/merge).

Part of [OSDEV-2920](https://opensupplyhub.atlassian.net/browse/OSDEV-2920). The GET moderation-events endpoints already return these fields; the backend change that makes **PATCH** return them too is in **opensupplyhub/open-supply-hub#1093**.

## ⚠️ Merge order

**This should merge _after_ opensupplyhub/open-supply-hub#1093 lands.** That PR aligns the PATCH response to actually return `os_id_snapshot` + coalesced `os_id`. Until it ships, this schema would document behavior the PATCH endpoint doesn't yet exhibit.

## Changes

- `docs/schemas/moderation_event.json`: add `os_id_snapshot`; update `os_id` description to note the fallback. Single shared schema now accurate for both GET and PATCH (no schema split needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)