### PR TITLE
[OSDEV-2951] Document is_closed in the production-locations response schema

### DIFF
--- a/docs/schemas/location.json
+++ b/docs/schemas/location.json
@@ -38,8 +38,8 @@
           "description": "Normalized address string returned by geocoding."
         },
         "is_closed": {
-          "type": ["boolean", "null"],
-          "description": "Indicates whether the production location is marked as closed. A location can be closed and later reopened, so use this flag rather than the closure dates to determine current status. Null when the closure status has never been recorded."
+          "type": "boolean",
+          "description": "Indicates whether the production location is marked as closed. A location can be closed and later reopened, so use this flag rather than the closure dates to determine current status. Omitted when the closure status has never been recorded."
         }
       }
     },

--- a/docs/schemas/location.json
+++ b/docs/schemas/location.json
@@ -38,8 +38,8 @@
           "description": "Normalized address string returned by geocoding."
         },
         "is_closed": {
-          "type": "boolean",
-          "description": "Indicates whether the production location is marked as closed. A location can be closed and later reopened, so use this flag rather than the closure dates to determine current status."
+          "type": ["boolean", "null"],
+          "description": "Indicates whether the production location is marked as closed. A location can be closed and later reopened, so use this flag rather than the closure dates to determine current status. Null when the closure status has never been recorded."
         }
       }
     },

--- a/docs/schemas/location.json
+++ b/docs/schemas/location.json
@@ -36,6 +36,10 @@
         "geocoded_address": {
           "type": "string",
           "description": "Normalized address string returned by geocoding."
+        },
+        "is_closed": {
+          "type": "boolean",
+          "description": "Indicates whether the production location is marked as closed. A location can be closed and later reopened, so use this flag rather than the closure dates to determine current status."
         }
       }
     },


### PR DESCRIPTION
## Jira Ticket
[OSDEV-2951](https://opensupplyhub.atlassian.net/browse/OSDEV-2951) (follow-up to [OSDEV-1149](https://opensupplyhub.atlassian.net/browse/OSDEV-1149), AC#2)

## Summary of Changes
Adds the `is_closed` property (boolean) to `docs/schemas/location.json`, the response schema for the `v1/production-locations` GET endpoints. Placed in the response-specific properties block (alongside `claim_status` / `geocoded_address`) rather than the claim fields, since `is_closed` is a top-level facility field, not claim data. The description notes that a location can close and later reopen, so this flag — not the closure dates — is the source of truth for current status.


## Null semantics
`is_closed` is documented as a plain boolean that is **omitted** when the closure status has never been recorded — the v1 API strips null values from responses, so the key is absent rather than `null` (verified against a local end-to-end sync).

## Dependency
⚠️ Do not merge before [open-supply-hub#1094](https://github.com/opensupplyhub/open-supply-hub/pull/1094), which adds `is_closed` to the endpoint (Logstash sync SQL + index mapping). Existing locations surface the field only after a production-locations reindex.

## Remaining for OSDEV-2951
The second half of the ticket — adding `is_closed` to the [RFC - Production Locations Endpoint Schema](https://opensupplyhub.atlassian.net/wiki/spaces/SD/pages/419659778) Confluence page — is handled separately (Confluence, not this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

